### PR TITLE
Removed LiDAR temporarily, modified speeds + distances

### DIFF
--- a/Mining_Research/Reset/startPosition/movement.cpp
+++ b/Mining_Research/Reset/startPosition/movement.cpp
@@ -9,22 +9,40 @@ extern AccelStepper stepperY;
 extern AccelStepper stepperX;
 extern const long deltaSteps;
 
-void Movement::moveYDown(int steps) {
-    stepperY.moveTo(stepperY.currentPosition() + steps * deltaSteps);
+// Fast motion profile for snappy short moves
+static inline void applyFastProfile(AccelStepper &s) {
+    s.setMaxSpeed(4000);      // velocity (steps/s)
+    s.setAcceleration(20000); // acceleration (steps/s^2)
+}
+
+void Movement::moveYDown(int steps)
+{
+    applyFastProfile(stepperY);
+    long target = stepperY.currentPosition() + (long)steps * deltaSteps;
+    stepperY.moveTo(target);
     Serial.println("Command: DOWN");
 }
 
-void Movement::moveYUp(int steps) {
-    stepperY.moveTo(stepperY.currentPosition() - steps * deltaSteps);
+void Movement::moveYUp(int steps)
+{
+    applyFastProfile(stepperY);
+    long target = stepperY.currentPosition() - (long)steps * deltaSteps;
+    stepperY.moveTo(target);
     Serial.println("Command: UP");
 }
 
-void Movement::moveXLeft(int steps) {
-    stepperX.moveTo(stepperX.currentPosition() + steps * deltaSteps);
+void Movement::moveXLeft(int steps)
+{
+    applyFastProfile(stepperX);
+    long target = stepperX.currentPosition() + (long)steps * deltaSteps;
+    stepperX.moveTo(target);
     Serial.println("Command: LEFT");
 }
 
-void Movement::moveXRight(int steps) {
-    stepperX.moveTo(stepperX.currentPosition() - steps * deltaSteps);
+void Movement::moveXRight(int steps)
+{
+    applyFastProfile(stepperX);
+    long target = stepperX.currentPosition() - (long)steps * deltaSteps;
+    stepperX.moveTo(target);
     Serial.println("Command: RIGHT");
 }

--- a/Mining_Research/runtest/movement.cpp
+++ b/Mining_Research/runtest/movement.cpp
@@ -9,22 +9,40 @@ extern AccelStepper stepperY;
 extern AccelStepper stepperX;
 extern const long deltaSteps;
 
-void Movement::moveYDown(int steps) {
-    stepperY.moveTo(stepperY.currentPosition() + steps * deltaSteps);
+// Fast motion profile for snappy short moves
+static inline void applyFastProfile(AccelStepper &s) {
+    s.setMaxSpeed(4000);      // velocity (steps/s)
+    s.setAcceleration(20000); // acceleration (steps/s^2)
+}
+
+void Movement::moveYDown(int steps)
+{
+    applyFastProfile(stepperY);
+    long target = stepperY.currentPosition() + (long)steps * deltaSteps;
+    stepperY.moveTo(target);
     Serial.println("Command: DOWN");
 }
 
-void Movement::moveYUp(int steps) {
-    stepperY.moveTo(stepperY.currentPosition() - steps * deltaSteps);
+void Movement::moveYUp(int steps)
+{
+    applyFastProfile(stepperY);
+    long target = stepperY.currentPosition() - (long)steps * deltaSteps;
+    stepperY.moveTo(target);
     Serial.println("Command: UP");
 }
 
-void Movement::moveXLeft(int steps) {
-    stepperX.moveTo(stepperX.currentPosition() + steps * deltaSteps);
+void Movement::moveXLeft(int steps)
+{
+    applyFastProfile(stepperX);
+    long target = stepperX.currentPosition() + (long)steps * deltaSteps;
+    stepperX.moveTo(target);
     Serial.println("Command: LEFT");
 }
 
-void Movement::moveXRight(int steps) {
-    stepperX.moveTo(stepperX.currentPosition() - steps * deltaSteps);
+void Movement::moveXRight(int steps)
+{
+    applyFastProfile(stepperX);
+    long target = stepperX.currentPosition() - (long)steps * deltaSteps;
+    stepperX.moveTo(target);
     Serial.println("Command: RIGHT");
 }

--- a/Mining_Research/runtest/runtest.ino
+++ b/Mining_Research/runtest/runtest.ino
@@ -31,29 +31,29 @@ bool loggingActive = false;
 bool autoRunning = false;
 
 // Read lidar
-uint16_t readTFmini(SoftwareSerial &lidarSerial) {
-  const uint8_t frameLength = 9;
-  uint16_t distance = 0;
-  if (lidarSerial.available() >= frameLength) {
-    while (lidarSerial.available()) {
-      if (lidarSerial.read() == 0x59 && lidarSerial.read() == 0x59) {
-        uint8_t frame[frameLength];
-        frame[0] = 0x59; frame[1] = 0x59;
-        for (int i = 2; i < frameLength; i++) {
-          while (!lidarSerial.available());
-          frame[i] = lidarSerial.read();
-        }
-        uint8_t checksum = 0;
-        for (int i = 0; i < 8; i++) checksum += frame[i];
-        if (checksum == frame[8]) {
-          distance = frame[2] | (frame[3] << 8);
-          return distance;
-        }
-      }
-    }
-  }
-  return distance;
-}
+//uint16_t readTFmini(SoftwareSerial &lidarSerial) {
+//  const uint8_t frameLength = 9;
+//  uint16_t distance = 0;
+//  if (lidarSerial.available() >= frameLength) {
+//    while (lidarSerial.available()) {
+//      if (lidarSerial.read() == 0x59 && lidarSerial.read() == 0x59) {
+//        uint8_t frame[frameLength];
+//        frame[0] = 0x59; frame[1] = 0x59;
+//        for (int i = 2; i < frameLength; i++) {
+//          while (!lidarSerial.available());
+//          frame[i] = lidarSerial.read();
+//        }
+//        uint8_t checksum = 0;
+//        for (int i = 0; i < 8; i++) checksum += frame[i];
+//        if (checksum == frame[8]) {
+//          distance = frame[2] | (frame[3] << 8);
+//          return distance;
+//        }
+//      }
+//    }
+//  }
+//  return distance;
+//}
 
 void setup() {
   Serial.begin(9600);
@@ -89,24 +89,24 @@ void loop() {
     }
 
     // Periodic sensor & position read
-    unsigned long now = millis();
-    if (now - lastSensorRead >= sensorInterval) {
-        lastSensorRead = now;
-        xLidarSerial.listen(); delay(2);
-        uint16_t tmpX = readTFmini(xLidarSerial);
-        if (tmpX) xLidarDistance = tmpX;
-        yLidarSerial.listen(); delay(2);
-        uint16_t tmpY = readTFmini(yLidarSerial);
-        if (tmpY) yLidarDistance = tmpY;
-
-        if (loggingActive) {
-            Serial.print(now); Serial.print(',');
-            Serial.print(stepperX.currentPosition()); Serial.print(',');
-            Serial.print(stepperY.currentPosition()); Serial.print(',');
-            Serial.print(xLidarDistance); Serial.print(',');
-            Serial.println(yLidarDistance);
-        }
-    }
+//    unsigned long now = millis();
+//    if (now - lastSensorRead >= sensorInterval) {
+//        lastSensorRead = now;
+//        xLidarSerial.listen(); delay(2);
+//        uint16_t tmpX = readTFmini(xLidarSerial);
+//        if (tmpX) xLidarDistance = tmpX;
+//        yLidarSerial.listen(); delay(2);
+//        uint16_t tmpY = readTFmini(yLidarSerial);
+//        if (tmpY) yLidarDistance = tmpY;
+//
+//        if (loggingActive) {
+//            Serial.print(now); Serial.print(',');
+//            Serial.print(stepperX.currentPosition()); Serial.print(',');
+//            Serial.print(stepperY.currentPosition()); Serial.print(',');
+//            Serial.print(xLidarDistance); Serial.print(',');
+//            Serial.println(yLidarDistance);
+//        }
+//    }
 
     // Run steppers
     stepperY.run();
@@ -128,28 +128,28 @@ void loop() {
         // 10 steps = 1.25", so 1 step = 1/8"
             switch (moveState) {
                 // Left to right sweep
-                case 0: movement.moveYDown(90); break;
+                case 0: movement.moveYDown(40); break;
                 case 1: movement.moveXLeft(20); break;
-                case 2: movement.moveYUp(90); break;
+                case 2: movement.moveYUp(40); break;
                 case 3: movement.moveXLeft(20); break;
-                case 4: movement.moveYDown(90); break;
+                case 4: movement.moveYDown(40); break;
                 case 5: movement.moveXLeft(20); break;
-                case 6: movement.moveYUp(90); break;
+                case 6: movement.moveYUp(40); break;
                 case 7: movement.moveXLeft(20); break;
-                case 8: movement.moveYDown(90); break;
+                case 8: movement.moveYDown(40); break;
                 case 9: movement.moveXLeft(20); break;
 
                 // Bottom to top sweep
                 case 10: movement.moveYUp(20); break;
-                case 11: movement.moveXRight(90); break;
+                case 11: movement.moveXRight(40); break;
                 case 12: movement.moveYUp(20); break;
-                case 13: movement.moveXLeft(90); break;
+                case 13: movement.moveXLeft(40); break;
                 case 14: movement.moveYUp(20); break;
-                case 15: movement.moveXRight(90); break;
+                case 15: movement.moveXRight(40); break;
                 case 16: movement.moveYUp(20); break;
-                case 17: movement.moveXLeft(90); break;
+                case 17: movement.moveXLeft(40); break;
                 case 18: movement.moveYUp(20); break;
-                case 19: movement.moveXRight(90); break;
+                case 19: movement.moveXRight(40); break;
 
                 default:
                     hasMoved = true;


### PR DESCRIPTION
- This change temporarily removes the LiDAR serial recording because the motors were observed to slow down after a period of time. Removing the LiDAR recording fixed this issue.
- Modifies the member functions to use a faster velocity and acceleration
- Modifies the distance the device moves