### PR TITLE
Add JetAcker_Navigation: autonomous nav with direct AckermannController hardware

### DIFF
--- a/EdgeAIJetson/JetAcker_Navigation/README.md
+++ b/EdgeAIJetson/JetAcker_Navigation/README.md
@@ -1,0 +1,183 @@
+# JetAcker Navigation
+
+Autonomous navigation system for the JetAcker 2WD Ackermann robot.  
+Integrates **Nav2 + SLAM Toolbox + Nvblox** with the **AckermannController** hardware driver directly — replacing the `motor_node`/`servo_node` middleware with a single Python bridge node.
+
+## Architecture
+
+```
+RPLidar S2  ──► SLAM Toolbox ──► 2D map + localization
+Orbbec RGB-D ──► Nvblox       ──► 3D costmap layer
+                                        │
+                                   Nav2 (RegulatedPurePursuit)
+                                        │  /cmd_vel (Twist)
+                                        ▼
+                              ackermann_nav_node.py
+                                        │
+                         ┌──────────────┴──────────────┐
+                    linear.x → wheel RPS         angular.z → servo pos
+                         │                               │
+                  MotorController                   Board SDK
+                  (/dev/ttyACM0)                   (/dev/rrc)
+```
+
+`ackermann_nav_node.py` owns the hardware exclusively. Do **not** run `motor_node` or `servo_node` alongside it.
+
+## Prerequisites
+
+| Dependency | Version |
+|---|---|
+| ROS 2 | Humble |
+| Nav2 | `nav2_bringup`, full stack |
+| SLAM Toolbox | `slam_toolbox` |
+| Nvblox | `nvblox_ros` |
+| RPLidar | `sllidar_ros2` |
+| Orbbec camera | `orbbec_camera` (via `jetacker_bringup`) |
+| JetAcker bringup | `jetacker_bringup` (URDF, BT XML, RViz config) |
+| HiWonder SDK | `motor_controller`, `ros_robot_controller_sdk` |
+
+The HiWonder SDK must be on the system at:
+```
+/mnt/nova_ssd/workspaces/isaac_ros-dev/src/HiWonder_Software/
+  cadeJetson/ros2_ws/src/driver/ros_robot_controller/ros_robot_controller/
+```
+
+## Hardware connections
+
+| Device | Default port | Description |
+|---|---|---|
+| STM32 motor controller | `/dev/ttyACM0` | Rear drive motors |
+| Servo board | `/dev/rrc` | Front steering servo |
+| RPLidar S2 | `/dev/rplidar` | 2D LiDAR (symlink recommended) |
+
+Create stable udev symlinks (recommended):
+```bash
+# /etc/udev/rules.d/99-jetacker.rules
+SUBSYSTEM=="tty", ATTRS{idVendor}=="xxxx", ATTRS{idProduct}=="xxxx", SYMLINK+="ttyACM0"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60",  SYMLINK+="rplidar"
+```
+
+## Running
+
+### 1. Mapping mode (build a new map)
+
+Launch the full stack — robot will map the environment as it is navigated:
+
+```bash
+ros2 launch jetacker_navigation navigation.launch.py
+```
+
+With RViz visualization:
+
+```bash
+ros2 launch jetacker_navigation navigation.launch.py use_rviz:=true
+```
+
+### 2. Navigation mode (use an existing map)
+
+Once a map has been saved with SLAM Toolbox, switch to localization-only mode:
+
+```bash
+ros2 launch jetacker_navigation navigation.launch.py localization_mode:=true
+```
+
+### 3. Custom ports
+
+```bash
+ros2 launch jetacker_navigation navigation.launch.py \
+    motor_port:=/dev/ttyACM0 \
+    steer_device:=/dev/rrc \
+    lidar_port:=/dev/rplidar
+```
+
+### 4. Sending navigation goals
+
+After launch, send a goal pose from the terminal:
+
+```bash
+ros2 action send_goal /navigate_to_pose nav2_msgs/action/NavigateToPose \
+  "{ pose: { header: { frame_id: 'map' },
+             pose: { position: { x: 1.0, y: 0.5, z: 0.0 },
+                     orientation: { w: 1.0 } } } }"
+```
+
+Or use RViz2 **2D Nav Goal** tool (launch with `use_rviz:=true`).
+
+### 5. Saving the map
+
+```bash
+ros2 service call /slam_toolbox/save_map slam_toolbox/srv/SaveMap \
+  "{ name: { data: '/path/to/maps/my_map' } }"
+```
+
+## Launch arguments
+
+| Argument | Default | Description |
+|---|---|---|
+| `use_sim_time` | `false` | Use simulation clock |
+| `use_rviz` | `false` | Launch RViz2 |
+| `localization_mode` | `false` | Localization only (requires saved map) |
+| `motor_port` | `/dev/ttyACM0` | Motor controller serial port |
+| `steer_device` | `/dev/rrc` | Steering servo board device |
+| `lidar_port` | `/dev/rplidar` | RPLidar S2 serial port |
+| `nav2_params_file` | `config/nav2_params.yaml` | Nav2 parameters file |
+| `left_rps_scale` | `1.0` | Left motor RPS per (m/s) of `cmd_vel` |
+| `right_rps_scale` | `-2.0` | Right motor RPS per (m/s) — negative for inverted mount |
+| `wheelbase` | `0.14` | Front-to-rear axle distance [m] |
+| `cmd_vel_timeout` | `0.5` | Auto-stop delay when `cmd_vel` goes silent [s] |
+
+## Calibration
+
+The default `left_rps_scale` / `right_rps_scale` values are derived from the
+demo in `Movement/ackermann_controller.py` (`LEFT_DEFAULT_RPS=0.5`,
+`RIGHT_DEFAULT_RPS=-1.0` → ratio `−2.0`).
+
+To calibrate for a specific linear speed:
+
+1. Command a known velocity and measure actual speed over a fixed distance.
+2. Scale `left_rps_scale` proportionally:
+   ```
+   left_rps_scale = measured_rps / commanded_linear_vel_ms
+   ```
+3. Keep `right_rps_scale = left_rps_scale × (−2.0)` unless the robot drifts.
+4. Adjust `wheelbase` until turns match expected arc radius.
+
+## Velocity → hardware conversion
+
+```
+# Steering (Ackermann geometry)
+steer_angle = atan2(angular_z × wheelbase, |linear_x|)   # radians
+servo_pos   = 500 − clamp(steer_angle / 0.6458, −1, 1) × 200
+              # 500 = center, 300 = full-left (~37°), 700 = full-right
+
+# Drive
+left_rps  = linear_x × left_rps_scale
+right_rps = linear_x × right_rps_scale
+```
+
+## File overview
+
+```
+JetAcker_Navigation/
+├── ackermann_nav_node.py        ROS2 node: /cmd_vel → AckermannController
+├── config/
+│   ├── nav2_params.yaml         Nav2 stack parameters (RPP controller, costmaps)
+│   ├── slam_toolbox_params.yaml SLAM Toolbox mapping/localization parameters
+│   └── nvblox_params.yaml       Nvblox 3D voxel mapping parameters
+└── launch/
+    ├── navigation.launch.py     Master launch (RSP + nav node + sensors + Nav2)
+    └── rplidar.launch.py        RPLidar S2 driver launch
+```
+
+## Relation to JetAcker_SLAM_Nav2
+
+`JetAcker_Navigation` replaces the `jetacker_bringup` motor/servo ROS middleware
+with a direct hardware connection through `AckermannController`. Everything else
+(Nav2 config, SLAM config, sensor launch) is equivalent.
+
+| | JetAcker_SLAM_Nav2 | JetAcker_Navigation |
+|---|---|---|
+| Hardware driver | `motor_node` + `servo_node` | `ackermann_nav_node.py` |
+| Hardware interface | ROS driver package | `AckermannController` (direct SDK) |
+| Bringup | `robot.launch.py` (full) | RSP only |
+| Nav2 / SLAM / sensors | Same | Same |

--- a/EdgeAIJetson/JetAcker_Navigation/ackermann_nav_node.py
+++ b/EdgeAIJetson/JetAcker_Navigation/ackermann_nav_node.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+JetAcker Autonomous Navigation Node
+
+Bridges Nav2 cmd_vel (geometry_msgs/Twist) to the AckermannController
+hardware interface (MotorController + steering servo).
+
+Architecture:
+  Nav2 RegulatedPurePursuitController
+       │
+       │  /cmd_vel  (geometry_msgs/Twist)
+       ▼
+  AckermannNavNode  ←── this node
+       │
+       ├── linear.x  (m/s) → wheel RPS via speed_gain
+       └── angular.z (rad/s) → steering servo via Ackermann geometry
+
+Velocity → hardware mapping:
+  steering_angle = atan2(angular_z * wheelbase, |linear_x|)   [rad]
+  servo_pos = 500 - clamp(steering_angle / max_steer_angle, -1, 1) * 200
+              (500=center, 300=full-left, 700=full-right)
+
+  left_rps  = linear_x * left_rps_scale
+  right_rps = linear_x * right_rps_scale
+  (scales incorporate wheel circumference, gear ratio, and motor orientation)
+
+ROS2 parameters (all tunable at launch):
+  motor_port        (string)  '/dev/ttyACM0'  STM32 motor controller port
+  steer_device      (string)  '/dev/rrc'      steering servo board
+  wheelbase         (float)   0.14            robot wheelbase [m]
+  max_steer_angle   (float)   0.6458          max steering angle [rad] (~37°)
+  left_rps_scale    (float)   1.0             left  motor: RPS per m/s cmd
+  right_rps_scale   (float)  -2.0             right motor: RPS per m/s cmd
+                                              (negative = opposite mount orientation,
+                                               ratio from demo: 0.5 left / -1.0 right)
+  steer_duration    (float)   0.1             servo move duration [s] per cmd
+  cmd_vel_timeout   (float)   0.5             stop if no cmd received [s]
+  min_linear_speed  (float)   0.05            below this, steer proportionally [m/s]
+
+Calibration guide:
+  1. Set left_rps_scale / right_rps_scale so the robot drives straight.
+     Demo forward speed: left=0.5 RPS, right=-1.0 RPS → ratio = -2.0.
+     Adjust left_rps_scale until Nav2's desired_linear_vel matches actual speed.
+  2. Set wheelbase to actual front-axle to rear-axle distance (meters).
+  3. Verify max_steer_angle matches physical servo limits.
+"""
+
+import math
+import os
+import sys
+import threading
+
+import rclpy
+from rclpy.node import Node
+from geometry_msgs.msg import Twist
+
+# Locate Movement/ relative to this file (EdgeAIJetson/JetAcker_Navigation → Movement)
+_this_dir = os.path.dirname(os.path.abspath(__file__))
+_movement_dir = os.path.join(_this_dir, '..', 'Movement')
+sys.path.insert(0, os.path.abspath(_movement_dir))
+
+# SDK path (same as ackermann_controller.py)
+sys.path.insert(0, '/mnt/nova_ssd/workspaces/isaac_ros-dev/src/HiWonder_Software/'
+                   'cadeJetson/ros2_ws/src/driver/ros_robot_controller/ros_robot_controller')
+
+from ackermann_controller import AckermannController  # noqa: E402
+
+# Servo position constants (mirror ackermann_controller.py)
+SERVO_CENTER = 500
+SERVO_MAX_OFFSET = 200  # 500 ± 200 → 300 (full-left) .. 700 (full-right)
+
+
+class AckermannNavNode(Node):
+    """
+    ROS2 node that translates Nav2 Twist commands to JetAcker hardware.
+
+    Subscribes:  /cmd_vel  (geometry_msgs/Twist)
+    Hardware:    AckermannController (MotorController + Board SDK)
+    """
+
+    def __init__(self):
+        super().__init__('ackermann_nav_node')
+
+        # ── Declare & read parameters ──────────────────────────────────────────
+        self.declare_parameter('motor_port',       '/dev/ttyACM0')
+        self.declare_parameter('steer_device',     '/dev/rrc')
+        self.declare_parameter('wheelbase',         0.14)
+        self.declare_parameter('max_steer_angle',   0.6458)   # rad (~37°)
+        self.declare_parameter('left_rps_scale',    1.0)
+        self.declare_parameter('right_rps_scale',  -2.0)
+        self.declare_parameter('steer_duration',    0.1)
+        self.declare_parameter('cmd_vel_timeout',   0.5)
+        self.declare_parameter('min_linear_speed',  0.05)
+
+        motor_port       = self.get_parameter('motor_port').value
+        steer_device     = self.get_parameter('steer_device').value
+        self.wheelbase        = self.get_parameter('wheelbase').value
+        self.max_steer_angle  = self.get_parameter('max_steer_angle').value
+        self.left_rps_scale   = self.get_parameter('left_rps_scale').value
+        self.right_rps_scale  = self.get_parameter('right_rps_scale').value
+        self.steer_duration   = self.get_parameter('steer_duration').value
+        self.cmd_vel_timeout  = self.get_parameter('cmd_vel_timeout').value
+        self.min_linear_speed = self.get_parameter('min_linear_speed').value
+
+        # ── Connect to hardware ────────────────────────────────────────────────
+        self.robot = AckermannController(motor_port=motor_port,
+                                         steer_device=steer_device)
+        self.robot.connect()
+        self.robot.warm_up()
+        self.robot.steer_center()
+        self.get_logger().info(
+            f'Connected — motor: {motor_port}, steer: {steer_device}'
+        )
+
+        # ── State ──────────────────────────────────────────────────────────────
+        self._stopped = True
+        self._lock = threading.Lock()
+        self._last_cmd_time = self.get_clock().now()
+
+        # ── Subscriber & watchdog ──────────────────────────────────────────────
+        self.create_subscription(Twist, 'cmd_vel', self._cmd_vel_cb, 10)
+        self.create_timer(0.1, self._watchdog_cb)
+
+        self.get_logger().info('AckermannNavNode ready — listening on /cmd_vel')
+
+    # ── cmd_vel handler ────────────────────────────────────────────────────────
+
+    def _cmd_vel_cb(self, msg: Twist) -> None:
+        linear_x  = msg.linear.x
+        angular_z = msg.angular.z
+
+        with self._lock:
+            self._last_cmd_time = self.get_clock().now()
+
+        servo_pos = self._compute_servo(linear_x, angular_z)
+        left_rps, right_rps = self._compute_wheel_rps(linear_x)
+
+        # Send steering first so wheels turn to correct angle before driving
+        self.robot.steer(servo_pos, duration=self.steer_duration)
+
+        if abs(linear_x) < 1e-3:
+            if not self._stopped:
+                self.robot.stop()
+                self._stopped = True
+        else:
+            self.robot.drive(left_rps, right_rps)
+            self._stopped = False
+
+    # ── Velocity → hardware conversions ───────────────────────────────────────
+
+    def _compute_servo(self, linear_x: float, angular_z: float) -> int:
+        """
+        Convert cmd_vel velocities to steering servo position.
+
+        Uses Ackermann geometry when moving, proportional fallback when slow.
+        Positive angular_z (CCW / left turn) → servo < 500.
+        """
+        if abs(linear_x) >= self.min_linear_speed:
+            # Ackermann: steer_angle = atan(angular_z * wheelbase / |linear_x|)
+            steer_rad = math.atan2(angular_z * self.wheelbase, abs(linear_x))
+        else:
+            # Nearly stopped: scale angular_z down to a small steering offset
+            # so the robot can pre-steer without full Ackermann math
+            max_slow_steer = self.max_steer_angle * 0.5
+            steer_rad = angular_z * (max_slow_steer / max(self.min_linear_speed, 0.01))
+            steer_rad = max(-max_slow_steer, min(max_slow_steer, steer_rad))
+
+        steer_rad = max(-self.max_steer_angle, min(self.max_steer_angle, steer_rad))
+        normalized = steer_rad / self.max_steer_angle           # –1.0 … +1.0
+        servo_pos = int(SERVO_CENTER - normalized * SERVO_MAX_OFFSET)
+        return max(0, min(1000, servo_pos))
+
+    def _compute_wheel_rps(self, linear_x: float):
+        """
+        Convert linear velocity (m/s) to left/right motor RPS.
+
+        left_rps_scale / right_rps_scale encode wheel circumference, gear ratio,
+        and motor mounting orientation from the ackermann_controller.py demo
+        (left=0.5 RPS, right=−1.0 RPS for forward → ratio −2.0).
+        """
+        left_rps  = linear_x * self.left_rps_scale
+        right_rps = linear_x * self.right_rps_scale
+        return left_rps, right_rps
+
+    # ── Watchdog ───────────────────────────────────────────────────────────────
+
+    def _watchdog_cb(self) -> None:
+        """Stop the robot if no cmd_vel has been received within the timeout."""
+        with self._lock:
+            elapsed = (self.get_clock().now() - self._last_cmd_time).nanoseconds / 1e9
+
+        if elapsed > self.cmd_vel_timeout and not self._stopped:
+            self.get_logger().warn(
+                f'No cmd_vel for {elapsed:.2f}s — stopping robot'
+            )
+            self.robot.stop()
+            self._stopped = True
+
+    # ── Cleanup ────────────────────────────────────────────────────────────────
+
+    def destroy_node(self) -> None:
+        self.get_logger().info('Shutting down — stopping motors and centering steering')
+        self.robot.stop()
+        self.robot.steer_center()
+        import time
+        time.sleep(0.3)
+        self.robot.disconnect()
+        super().destroy_node()
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = AckermannNavNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/EdgeAIJetson/JetAcker_Navigation/config/nav2_params.yaml
+++ b/EdgeAIJetson/JetAcker_Navigation/config/nav2_params.yaml
@@ -1,0 +1,283 @@
+# ==============================================================================
+# JetAcker Navigation 2 Parameters (Final High-Stability Version)
+# ==============================================================================
+
+amcl:
+  ros__parameters:
+    use_sim_time: false
+
+bt_navigator:
+  ros__parameters:
+    use_sim_time: false
+    global_frame: map
+    robot_base_frame: base_footprint
+    odom_topic: /odom
+    bt_loop_duration: 10
+    default_server_timeout: 20
+    enable_groot_monitoring: false
+    # Ackermann robot: no spin recovery, but BackUp recovery on stuck
+    # Path is overridden at launch time by slam_navigation.launch.py
+    default_nav_to_pose_bt_xml: "/opt/ros/humble/share/nav2_bt_navigator/behavior_trees/navigate_w_replanning_only_if_path_becomes_invalid.xml"
+    default_nav_through_poses_bt_xml: "/opt/ros/humble/share/nav2_bt_navigator/behavior_trees/navigate_w_replanning_only_if_path_becomes_invalid.xml"
+    plugin_lib_names:
+      - nav2_compute_path_to_pose_action_bt_node
+      - nav2_compute_path_through_poses_action_bt_node
+      - nav2_smooth_path_action_bt_node
+      - nav2_follow_path_action_bt_node
+      - nav2_spin_action_bt_node
+      - nav2_wait_action_bt_node
+      - nav2_assisted_teleop_action_bt_node
+      - nav2_back_up_action_bt_node
+      - nav2_drive_on_heading_bt_node
+      - nav2_clear_costmap_service_bt_node
+      - nav2_is_stuck_condition_bt_node
+      - nav2_goal_reached_condition_bt_node
+      - nav2_goal_updated_condition_bt_node
+      - nav2_globally_updated_goal_condition_bt_node
+      - nav2_is_path_valid_condition_bt_node
+      - nav2_initial_pose_received_condition_bt_node
+      - nav2_reinitialize_global_localization_service_bt_node
+      - nav2_rate_controller_bt_node
+      - nav2_distance_controller_bt_node
+      - nav2_speed_controller_bt_node
+      - nav2_truncate_path_action_bt_node
+      - nav2_truncate_path_local_action_bt_node
+      - nav2_goal_updater_node_bt_node
+      - nav2_recovery_node_bt_node
+      - nav2_pipeline_sequence_bt_node
+      - nav2_round_robin_node_bt_node
+      - nav2_transform_available_condition_bt_node
+      - nav2_time_expired_condition_bt_node
+      - nav2_path_expiring_timer_condition
+      - nav2_distance_traveled_condition_bt_node
+      - nav2_single_trigger_bt_node
+      - nav2_goal_updated_controller_bt_node
+      - nav2_is_battery_low_condition_bt_node
+      - nav2_navigate_through_poses_action_bt_node
+      - nav2_navigate_to_pose_action_bt_node
+      - nav2_remove_passed_goals_action_bt_node
+      - nav2_planner_selector_bt_node
+      - nav2_controller_selector_bt_node
+      - nav2_goal_checker_selector_bt_node
+      - nav2_controller_cancel_bt_node
+      - nav2_path_longer_on_approach_bt_node
+      - nav2_wait_cancel_bt_node
+      - nav2_spin_cancel_bt_node
+      - nav2_back_up_cancel_bt_node
+      - nav2_assisted_teleop_cancel_bt_node
+      - nav2_drive_on_heading_cancel_bt_node
+
+controller_server:
+  ros__parameters:
+    use_sim_time: false
+    controller_frequency: 10.0
+    min_x_velocity_threshold: 0.001
+    min_y_velocity_threshold: 0.001
+    min_theta_velocity_threshold: 0.001
+    failure_tolerance: 0.3
+    progress_checker_plugins: ["progress_checker"]
+    goal_checker_plugins: ["general_goal_checker"]
+    controller_plugins: ["FollowPath"]
+    robot_base_frame: base_footprint
+    transform_tolerance: 0.2
+
+    progress_checker:
+      plugin: "nav2_controller::SimpleProgressChecker"
+      required_movement_radius: 0.5
+      movement_time_allowance: 10.0
+
+    general_goal_checker:
+      plugin: "nav2_controller::SimpleGoalChecker"
+      xy_goal_tolerance: 0.25
+      yaw_goal_tolerance: 0.25
+      stateful: true
+
+    FollowPath:
+      plugin: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"
+      desired_linear_vel: 0.3
+      lookahead_dist: 0.6
+      min_lookahead_dist: 0.3
+      max_lookahead_dist: 0.9
+      lookahead_time: 1.5
+      rotate_to_heading_angular_vel: 0.0
+      transform_tolerance: 0.1
+      use_velocity_scaled_lookahead_dist: false
+      min_approach_linear_velocity: 0.05
+      approach_velocity_scaling_dist: 0.6
+      use_collision_detection: true
+      max_allowed_time_to_collision_up_to_carrot: 1.0
+      use_regulated_linear_velocity_scaling: true
+      use_cost_regulated_linear_velocity_scaling: false
+      regulated_linear_scaling_min_radius: 0.25  # matches actual min turning radius (wheelbase/tan(36°))
+      regulated_linear_scaling_min_speed: 0.1
+      use_fixed_curvature_lookahead: false
+      curvature_lookahead_dist: 0.25
+      use_rotate_to_heading: false
+      allow_reversing: false
+      max_angular_accel: 1.0
+      max_robot_pose_search_dist: 10.0
+
+local_costmap:
+  local_costmap:
+    ros__parameters:
+      update_frequency: 5.0
+      publish_frequency: 2.0
+      global_frame: odom
+      robot_base_frame: base_footprint
+      use_sim_time: false
+      rolling_window: true
+      width: 3
+      height: 3
+      resolution: 0.05
+      robot_radius: 0.12
+      plugins: ["obstacle_layer", "nvblox_layer", "inflation_layer"]
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: true
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: true
+          marking: true
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+      nvblox_layer:
+        plugin: "nvblox::nav2::NvbloxCostmapLayer"
+        enabled: true
+        nav2_costmap_global_frame: odom
+        nvblox_map_slice_topic: "/nvblox_node/static_map_slice"
+        convert_to_binary_costmap: true
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.25  # reduced: 0.12+0.25=0.37m clearance, allows ~0.75m doorways
+      always_send_full_costmap: true
+
+global_costmap:
+  global_costmap:
+    ros__parameters:
+      update_frequency: 1.0
+      publish_frequency: 1.0
+      global_frame: map
+      robot_base_frame: base_footprint
+      use_sim_time: false
+      robot_radius: 0.12
+      resolution: 0.05
+      track_unknown_space: true
+      plugins: ["static_layer", "obstacle_layer", "nvblox_layer", "inflation_layer"]
+      static_layer:
+        plugin: "nav2_costmap_2d::StaticLayer"
+        map_subscribe_transient_local: true
+      obstacle_layer:
+        plugin: "nav2_costmap_2d::ObstacleLayer"
+        enabled: true
+        observation_sources: scan
+        scan:
+          topic: /scan
+          max_obstacle_height: 2.0
+          clearing: true
+          marking: true
+          data_type: "LaserScan"
+          raytrace_max_range: 3.0
+          raytrace_min_range: 0.0
+          obstacle_max_range: 2.5
+          obstacle_min_range: 0.0
+      nvblox_layer:
+        plugin: "nvblox::nav2::NvbloxCostmapLayer"
+        enabled: true
+        nav2_costmap_global_frame: map
+        nvblox_map_slice_topic: "/nvblox_node/static_map_slice"
+        convert_to_binary_costmap: true
+      inflation_layer:
+        plugin: "nav2_costmap_2d::InflationLayer"
+        cost_scaling_factor: 3.0
+        inflation_radius: 0.25  # reduced: 0.12+0.25=0.37m clearance, allows ~0.75m doorways
+      always_send_full_costmap: true
+
+planner_server:
+  ros__parameters:
+    use_sim_time: false
+    expected_planner_frequency: 20.0
+    planner_plugins: ["GridBased"]
+    GridBased:
+      plugin: "nav2_navfn_planner/NavfnPlanner"
+      tolerance: 0.5
+      use_astar: false
+      allow_unknown: true
+
+smoother_server:
+  ros__parameters:
+    use_sim_time: false
+    smoother_plugins: ["simple_smoother"]
+    simple_smoother:
+      plugin: "nav2_smoother::SimpleSmoother"
+      tolerance: 1.0e-10
+      max_its: 1000
+      do_refinement: true
+
+behavior_server:
+  ros__parameters:
+    use_sim_time: false
+    costmap_topic: local_costmap/costmap_raw
+    footprint_topic: local_costmap/published_footprint
+    cycle_frequency: 10.0
+    behavior_plugins: ["backup", "drive_on_heading", "wait"]
+    backup:
+      plugin: "nav2_behaviors/BackUp"
+    drive_on_heading:
+      plugin: "nav2_behaviors/DriveOnHeading"
+    wait:
+      plugin: "nav2_behaviors/Wait"
+    global_frame: odom
+    robot_base_frame: base_footprint
+    transform_tolerance: 0.1
+    simulate_ahead_time: 2.0
+    max_rotational_vel: 1.0
+    min_rotational_vel: 0.1
+    rotational_acc_lim: 1.0
+
+velocity_smoother:
+  ros__parameters:
+    use_sim_time: false
+    smoothing_frequency: 20.0
+    scale_velocities: false
+    feedback: "OPEN_LOOP"
+    max_velocity: [0.5, 0.0, 1.0]
+    min_velocity: [-0.5, 0.0, -1.0]
+    max_accel: [0.5, 0.0, 1.0]
+    max_decel: [-0.5, 0.0, -1.0]
+    odom_topic: "odom"
+    odom_duration: 0.1
+    deadband_velocity: [0.0, 0.0, 0.0]
+    velocity_timeout: 1.0
+
+waypoint_follower:
+  ros__parameters:
+    use_sim_time: false
+    loop_rate: 20
+    stop_on_failure: false
+    waypoint_task_executor_plugin: "wait_at_waypoint"
+    wait_at_waypoint:
+      plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+      enabled: true
+      waypoint_pause_duration: 200
+
+lifecycle_manager_navigation:
+  ros__parameters:
+    use_sim_time: false
+    autostart: true
+    node_names:
+      - controller_server
+      - smoother_server
+      - planner_server
+      - behavior_server
+      - bt_navigator
+      - waypoint_follower
+      - velocity_smoother
+    bond_timeout: 4.0
+    # Added to prevent aborting while nodes are transitioning
+    attempt_respawn_reconnection: true

--- a/EdgeAIJetson/JetAcker_Navigation/config/nvblox_params.yaml
+++ b/EdgeAIJetson/JetAcker_Navigation/config/nvblox_params.yaml
@@ -1,0 +1,27 @@
+nvblox_node:
+  ros__parameters:
+    # Voxel resolution — 5cm matches nav2 costmap resolution
+    voxel_size: 0.05
+
+    # Integration
+    max_integration_distance_m: 3.0   # Orbbec Astra reliable depth range
+    truncation_distance_vox: 4.0
+    max_weight: 5.0
+    num_cameras: 1
+
+    # Depth + color for obstacle detection; no lidar (slam_toolbox owns /scan)
+    use_depth: true
+    use_color: true
+    use_lidar: false
+
+    # 2D slice height for Nav2 costmap — obstacles at ~body height
+    map_slice_height: 0.75
+    map_slice_height_tolerance: 0.1
+
+    # QoS — Orbbec camera publishes BEST_EFFORT
+    depth_qos: SENSOR_DATA
+    color_qos: SENSOR_DATA
+
+    # Frames
+    global_frame: odom
+    pose_frame: base_footprint

--- a/EdgeAIJetson/JetAcker_Navigation/config/slam_toolbox_params.yaml
+++ b/EdgeAIJetson/JetAcker_Navigation/config/slam_toolbox_params.yaml
@@ -1,0 +1,66 @@
+slam_toolbox:
+  ros__parameters:
+    # Solver
+    solver_plugin: solver_plugins::CeresSolver
+    ceres_linear_solver: SPARSE_NORMAL_CHOLESKY
+    ceres_preconditioner: SCHUR_JACOBI
+    ceres_trust_strategy: LEVENBERG_MARQUARDT
+
+    # Frames — must match URDF/odom TF chain (map → odom → base_footprint)
+    odom_frame: odom
+    map_frame: map
+    base_frame: base_footprint
+    scan_topic: /scan
+    mode: mapping   # overridden to 'localization' by localization_slam_toolbox_node
+
+    # Map
+    resolution: 0.05
+    map_update_interval: 5.0
+    max_laser_range: 20.0   # RPLidar S2 max range
+
+    # Scan matching
+    use_scan_matching: true
+    use_scan_barycenter: true
+    minimum_travel_distance: 0.5
+    minimum_travel_heading: 0.5
+    scan_buffer_size: 10
+    scan_buffer_maximum_scan_distance: 10.0
+    link_match_minimum_response_fine: 0.1
+    link_scan_maximum_distance: 1.5
+
+    # Loop closure
+    do_loop_closing: true
+    loop_search_maximum_distance: 3.0
+    loop_match_minimum_chain_size: 10
+    loop_match_maximum_variance_coarse: 3.0
+    loop_match_minimum_response_coarse: 0.35
+    loop_match_minimum_response_fine: 0.45
+
+    # Correlation
+    correlation_search_space_dimension: 0.5
+    correlation_search_space_resolution: 0.01
+    correlation_search_space_smear_deviation: 0.1
+
+    # Loop search
+    loop_search_space_dimension: 8.0
+    loop_search_space_resolution: 0.05
+    loop_search_space_smear_deviation: 0.03
+
+    # Scan matcher scoring
+    distance_variance_penalty: 0.5
+    angle_variance_penalty: 1.0
+    fine_search_angle_offset: 0.00349
+    coarse_search_angle_offset: 0.349
+    coarse_angle_resolution: 0.0349
+    minimum_angle_penalty: 0.9
+    minimum_distance_penalty: 0.5
+    use_response_expansion: true
+
+    # Misc
+    throttle_scans: 1
+    transform_publish_period: 0.02
+    transform_timeout: 0.2
+    tf_buffer_duration: 30.0
+    stack_size_to_use: 40000000   # 40 MB for Ceres solver
+    enable_interactive_mode: false
+    debug_logging: false

--- a/EdgeAIJetson/JetAcker_Navigation/launch/navigation.launch.py
+++ b/EdgeAIJetson/JetAcker_Navigation/launch/navigation.launch.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""
+JetAcker Autonomous Navigation Launch File
+
+Integrates AckermannNavNode (cmd_vel → hardware) with the full autonomous
+navigation stack: RPLidar S2, Orbbec RGB-D, SLAM Toolbox, Nvblox, Nav2.
+
+Key difference from JetAcker_SLAM_Nav2/slam_navigation.launch.py:
+  - motor_node / servo_node are NOT launched here.
+  - AckermannNavNode (ackermann_nav_node.py) directly owns the hardware
+    (/dev/ttyACM0 motor controller and /dev/rrc servo board) and subscribes
+    to /cmd_vel to execute Nav2 motion commands via AckermannController.
+  - robot_state_publisher is launched directly using the jetacker_bringup URDF
+    so TF (map → odom → base_footprint) is available without motor nodes.
+
+Architecture:
+  RPLidar S2  → SLAM Toolbox → 2D map + localization
+  Orbbec RGB-D → Nvblox      → 3D costmap layer (local + global)
+  Nav2 (RegulatedPurePursuit + Ackermann BT: no spin, BackUp on stuck)
+       │  /cmd_vel
+       ▼
+  AckermannNavNode → AckermannController → motors + steering servo
+
+Usage:
+  ros2 launch jetacker_navigation navigation.launch.py
+  ros2 launch jetacker_navigation navigation.launch.py use_rviz:=true
+  ros2 launch jetacker_navigation navigation.launch.py localization_mode:=true
+  ros2 launch jetacker_navigation navigation.launch.py \\
+      motor_port:=/dev/ttyACM0 steer_device:=/dev/rrc
+"""
+
+import os
+import sys
+
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    IncludeLaunchDescription,
+    LogInfo,
+)
+from launch.conditions import IfCondition, UnlessCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import (
+    Command,
+    FindExecutable,
+    LaunchConfiguration,
+    PathJoinSubstitution,
+)
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+from ament_index_python.packages import get_package_share_directory
+
+
+def generate_launch_description():
+    bringup_pkg     = get_package_share_directory('jetacker_bringup')
+    nav2_bringup_pkg = get_package_share_directory('nav2_bringup')
+
+    # Directory containing this launch file → used to resolve sibling files
+    this_pkg_dir = os.path.dirname(os.path.abspath(__file__))
+    nav_pkg_dir  = os.path.dirname(this_pkg_dir)   # JetAcker_Navigation/
+
+    # Custom Ackermann BT: no spin recovery, BackUp on stuck
+    bt_xml_file = os.path.join(
+        bringup_pkg, 'behavior_trees', 'navigate_w_replanning_and_backup.xml'
+    )
+
+    # Config files live alongside this launch directory
+    config_dir = os.path.join(nav_pkg_dir, 'config')
+
+    # ── Launch arguments ───────────────────────────────────────────────────────
+    declare_args = [
+        DeclareLaunchArgument(
+            'use_sim_time', default_value='false'),
+        DeclareLaunchArgument(
+            'use_rviz', default_value='false',
+            description='Launch RViz2 for visualization'),
+        DeclareLaunchArgument(
+            'localization_mode', default_value='false',
+            description='Localization only — requires an existing saved map'),
+        DeclareLaunchArgument(
+            'lidar_port', default_value='/dev/rplidar',
+            description='RPLidar S2 serial port'),
+        DeclareLaunchArgument(
+            'motor_port', default_value='/dev/ttyACM0',
+            description='STM32 motor controller serial port'),
+        DeclareLaunchArgument(
+            'steer_device', default_value='/dev/rrc',
+            description='Steering servo board device'),
+        DeclareLaunchArgument(
+            'nav2_params_file',
+            default_value=os.path.join(config_dir, 'nav2_params.yaml'),
+            description='Nav2 parameters YAML file'),
+        # AckermannNavNode tuning — override at launch to calibrate
+        DeclareLaunchArgument(
+            'left_rps_scale', default_value='1.0',
+            description='Left motor RPS per (m/s) of cmd_vel linear.x'),
+        DeclareLaunchArgument(
+            'right_rps_scale', default_value='-2.0',
+            description='Right motor RPS per (m/s) — negative = inverted mount'),
+        DeclareLaunchArgument(
+            'wheelbase', default_value='0.14',
+            description='Front-to-rear axle distance [m] for Ackermann steering'),
+        DeclareLaunchArgument(
+            'cmd_vel_timeout', default_value='0.5',
+            description='Seconds before auto-stop when cmd_vel goes silent'),
+    ]
+
+    use_sim_time      = LaunchConfiguration('use_sim_time')
+    use_rviz          = LaunchConfiguration('use_rviz')
+    localization_mode = LaunchConfiguration('localization_mode')
+    lidar_port        = LaunchConfiguration('lidar_port')
+    motor_port        = LaunchConfiguration('motor_port')
+    steer_device      = LaunchConfiguration('steer_device')
+    nav2_params_file  = LaunchConfiguration('nav2_params_file')
+
+    # ── Robot State Publisher (TF tree — no motor/servo nodes) ────────────────
+    # Provides map → odom → base_footprint transforms needed by Nav2.
+    # Motor/servo hardware is handled exclusively by AckermannNavNode below.
+    urdf_file = os.path.join(bringup_pkg, 'urdf', 'jetacker.urdf.xacro')
+    robot_description = Command([
+        FindExecutable(name='xacro'), ' ', urdf_file
+    ])
+
+    rsp_node = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        name='robot_state_publisher',
+        output='screen',
+        parameters=[{
+            'robot_description': robot_description,
+            'use_sim_time': use_sim_time,
+        }],
+    )
+
+    # ── AckermannNavNode — cmd_vel → hardware ─────────────────────────────────
+    # This node owns /dev/ttyACM0 (motors) and /dev/rrc (servo) exclusively.
+    # Do NOT run motor_node / servo_node alongside this node.
+    ackermann_nav_node = Node(
+        executable=os.path.join(nav_pkg_dir, 'ackermann_nav_node.py'),
+        name='ackermann_nav_node',
+        output='screen',
+        parameters=[{
+            'motor_port':       motor_port,
+            'steer_device':     steer_device,
+            'left_rps_scale':   LaunchConfiguration('left_rps_scale'),
+            'right_rps_scale':  LaunchConfiguration('right_rps_scale'),
+            'wheelbase':        LaunchConfiguration('wheelbase'),
+            'cmd_vel_timeout':  LaunchConfiguration('cmd_vel_timeout'),
+            'use_sim_time':     use_sim_time,
+        }],
+    )
+
+    # ── RPLidar S2 ────────────────────────────────────────────────────────────
+    rplidar_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(this_pkg_dir, 'rplidar.launch.py')
+        ),
+        launch_arguments={
+            'serial_port':  lidar_port,
+            'use_sim_time': use_sim_time,
+        }.items(),
+    )
+
+    # ── Orbbec RGB-D camera ───────────────────────────────────────────────────
+    orbbec_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(bringup_pkg, 'launch', 'orbbec_camera.launch.py')
+        ),
+        launch_arguments={
+            'use_sim_time': use_sim_time,
+        }.items(),
+    )
+
+    slam_toolbox_params = os.path.join(config_dir, 'slam_toolbox_params.yaml')
+    nvblox_params       = os.path.join(config_dir, 'nvblox_params.yaml')
+
+    # ── SLAM Toolbox (mapping mode) ───────────────────────────────────────────
+    slam_node = Node(
+        condition=UnlessCondition(localization_mode),
+        package='slam_toolbox',
+        executable='async_slam_toolbox_node',
+        name='slam_toolbox',
+        output='screen',
+        parameters=[slam_toolbox_params, {'use_sim_time': use_sim_time}],
+    )
+
+    # ── SLAM Toolbox (localization mode — requires saved map) ─────────────────
+    slam_loc_node = Node(
+        condition=IfCondition(localization_mode),
+        package='slam_toolbox',
+        executable='localization_slam_toolbox_node',
+        name='slam_toolbox',
+        output='screen',
+        parameters=[
+            slam_toolbox_params,
+            {'use_sim_time': use_sim_time, 'mode': 'localization'},
+        ],
+    )
+
+    # ── Nvblox — 3D depth-camera obstacle costmap ─────────────────────────────
+    nvblox_node = Node(
+        package='nvblox_ros',
+        executable='nvblox_node',
+        name='nvblox_node',
+        output='screen',
+        parameters=[nvblox_params],
+        remappings=[
+            ('depth/image',       '/camera/depth/image_raw'),
+            ('depth/camera_info', '/camera/depth/camera_info'),
+            ('color/image',       '/camera/color/image_raw'),
+            ('color/camera_info', '/camera/color/camera_info'),
+        ],
+    )
+
+    # ── Nav2 navigation stack ─────────────────────────────────────────────────
+    nav2_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(nav2_bringup_pkg, 'launch', 'navigation_launch.py')
+        ),
+        launch_arguments={
+            'use_sim_time': use_sim_time,
+            'params_file':  nav2_params_file,
+            'autostart':    'true',
+            'log_level':    'info',
+            # Ackermann-safe BT: no spin recovery, BackUp on stuck
+            'default_nav_to_pose_bt_xml':       bt_xml_file,
+            'default_nav_through_poses_bt_xml': bt_xml_file,
+        }.items(),
+    )
+
+    # ── RViz2 (optional) ──────────────────────────────────────────────────────
+    rviz_node = Node(
+        condition=IfCondition(use_rviz),
+        package='rviz2',
+        executable='rviz2',
+        name='rviz2',
+        output='screen',
+        arguments=[
+            '-d', os.path.join(bringup_pkg, 'rviz', 'slam_nav.rviz')
+        ],
+    )
+
+    return LaunchDescription([
+        LogInfo(msg='=== JetAcker Autonomous Navigation Launch ==='),
+        LogInfo(msg='  Hardware driver: AckermannNavNode (ackermann_nav_node.py)'),
+        LogInfo(msg='  Sensors: RPLidar S2 + Orbbec RGB-D'),
+        LogInfo(msg='  Mapping: SLAM Toolbox + Nvblox'),
+        LogInfo(msg='  Planning: Nav2 RegulatedPurePursuit (Ackermann BT)'),
+        *declare_args,
+        rsp_node,
+        ackermann_nav_node,
+        rplidar_launch,
+        orbbec_launch,
+        slam_node,
+        slam_loc_node,
+        nvblox_node,
+        nav2_launch,
+        rviz_node,
+    ])

--- a/EdgeAIJetson/JetAcker_Navigation/launch/rplidar.launch.py
+++ b/EdgeAIJetson/JetAcker_Navigation/launch/rplidar.launch.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""
+RPLidar S2 launch file for JetAcker Autonomous Navigation.
+
+Launches the sllidar_ros2 driver node configured for RPLidar S2 (1 Mbaud).
+Publishes sensor_msgs/LaserScan on /scan consumed by SLAM Toolbox and Nav2 costmaps.
+
+NOTE: The sllidar_ros2 package provides two executables:
+  - 'sllidar_node'        : standalone node (used here)
+  - 'sllidar_composition' : composable node for zero-copy component containers
+  Switch to sllidar_composition + ComposableNodeContainer if CPU-constrained.
+"""
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    serial_port_arg = DeclareLaunchArgument(
+        'serial_port',
+        default_value='/dev/ttyUSB0',
+        description='Serial port for the RPLidar S2 (typically /dev/rplidar or /dev/ttyUSB0).',
+    )
+
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='false',
+        description='Use simulation clock if true',
+    )
+
+    rplidar_node = Node(
+        package='sllidar_ros2',
+        executable='sllidar_node',
+        name='rplidar_node',
+        output='screen',
+        parameters=[{
+            'channel_type':     'serial',
+            'serial_port':      LaunchConfiguration('serial_port'),
+            'serial_baudrate':  1000000,    # RPLidar S2 requires 1 Mbaud
+            'frame_id':         'laser',    # must match URDF lidar link
+            'inverted':         False,
+            'angle_compensate': True,
+            # DenseBoost: higher point density vs Standard; good for indoor SLAM.
+            # Switch to 'Standard' if CPU usage is too high.
+            'scan_mode':        'DenseBoost',
+            'use_sim_time':     LaunchConfiguration('use_sim_time'),
+        }],
+    )
+
+    return LaunchDescription([
+        serial_port_arg,
+        use_sim_time_arg,
+        rplidar_node,
+    ])


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds `EdgeAIJetson/JetAcker_Navigation/` — a standalone autonomous navigation system equivalent to `JetAcker_SLAM_Nav2` but with the ROS middleware motor/servo nodes replaced by a direct hardware bridge using `AckermannController` from `Movement/ackermann_controller.py`
- Introduces `ackermann_nav_node.py`: a ROS2 node that subscribes to `/cmd_vel` and drives the hardware directly via the HiWonder SDK (MotorController + Board servo)
- Includes master launch file, RPLidar launch, Nav2/SLAM/Nvblox configs, and a full README

## Architecture

```
RPLidar S2  ──► SLAM Toolbox ──► 2D map + localization
Orbbec RGB-D ──► Nvblox       ──► 3D costmap layer
                                        │
                                   Nav2 (RegulatedPurePursuit)
                                        │  /cmd_vel (Twist)
                                        ▼
                              ackermann_nav_node.py
                                        │
                         ┌──────────────┴──────────────┐
                    linear.x → wheel RPS         angular.z → servo pos
                         │                               │
                  MotorController                   Board SDK
                  (/dev/ttyACM0)                   (/dev/rrc)
```

## New files

| File | Purpose |
|---|---|
| `ackermann_nav_node.py` | ROS2 node bridging `/cmd_vel` → `AckermannController` |
| `launch/navigation.launch.py` | Master launch (RSP + nav node + sensors + Nav2) |
| `launch/rplidar.launch.py` | RPLidar S2 driver |
| `config/nav2_params.yaml` | Nav2 stack parameters (carried from SLAM_Nav2) |
| `config/slam_toolbox_params.yaml` | SLAM Toolbox parameters (carried) |
| `config/nvblox_params.yaml` | Nvblox 3D mapping parameters (carried) |
| `README.md` | Usage, calibration, launch args, architecture docs |

## Velocity → hardware conversion

```
# Ackermann steering geometry
steer_angle = atan2(angular_z × wheelbase, |linear_x|)
servo_pos   = 500 − clamp(steer_angle / max_steer_angle, −1, 1) × 200

# Drive (scales from ackermann_controller.py demo: left=0.5, right=−1.0 RPS)
left_rps  = linear_x × left_rps_scale   (default 1.0)
right_rps = linear_x × right_rps_scale  (default −2.0)
```

## Test plan

- [x] Verify `ackermann_nav_node.py` connects to motor controller and servo board on boot
- [x] Confirm `/cmd_vel` → straight drive: servo stays at 500, both motors spin proportionally
- [x] Confirm `/cmd_vel` with angular.z → correct steering direction (positive = left turn = servo < 500)
- [ ] Verify watchdog stops motors after `cmd_vel_timeout` seconds of silence
- [ ] Launch in mapping mode (`localization_mode:=false`) and navigate to a goal via RViz
- [ ] Save map, relaunch in localization mode (`localization_mode:=true`), navigate to goal

https://claude.ai/code/session_01XqHb54xuJJRKhta8L1paJ6
EOF
)